### PR TITLE
Add search plugin to home page

### DIFF
--- a/app/views/general.scala.html
+++ b/app/views/general.scala.html
@@ -9,6 +9,7 @@
         <title>@title</title>
         <link rel="stylesheet" href="@routes.Assets.at("css/foundation.css")" />
         <link rel="stylesheet" href="@routes.Assets.at("css/style.css")" />
+        <link rel="search" type="application/opensearchdescription+xml" href="@routes.Assets.at("xml/criticalreview.xml")" title="Critical Review" />
         <script type="text/javascript" src="@routes.Assets.at("js/modernizr.js")"></script>
         <script type="text/javascript" src="@routes.Assets.at("js/jquery.js")"></script>
         <script type="text/javascript" src="@routes.Assets.at("js/foundation/foundation.js")"></script>

--- a/public/xml/criticalreview.xml
+++ b/public/xml/criticalreview.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+	<ShortName>Critical Review</ShortName>
+	<Description>Search The Critical Review at Brown University</Description>
+	<Image height="16" width="16" type="image/x-icon">http://www.thecriticalreview.org/favicon.ico</Image>
+	<Url type="text/html" method="get" template="http://www.thecriticalreview.org/search?q={searchTerms};sourceid=open-search"/>
+</OpenSearchDescription>


### PR DESCRIPTION
I added the opensearch xml file from the old website to the public
directory and included it on the home page. This adds search
integration for Chrome and Firefox.

Resolves issue #22
